### PR TITLE
fix: replace pkg_resources with importlib

### DIFF
--- a/src/experimaestro/launcherfinder/registry.py
+++ b/src/experimaestro/launcherfinder/registry.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Dict, Optional, Set, Type, Union
 from pathlib import Path
 import typing
 from omegaconf import DictConfig, OmegaConf, SCMode
-import pkg_resources
+from importlib.metadata import entry_points
 from experimaestro.utils import logger
 from .base import ConnectorConfiguration, TokenConfiguration
 from .specs import HostRequirement, RequirementUnion
@@ -75,10 +75,10 @@ class LauncherRegistry:
         self.find_launcher_fn = None
 
         # Use entry points for connectors and launchers
-        for entry_point in pkg_resources.iter_entry_points("experimaestro.connectors"):
+        for entry_point in entry_points(group="experimaestro.connectors"):
             entry_point.load().init_registry(self)
 
-        for entry_point in pkg_resources.iter_entry_points("experimaestro.tokens"):
+        for entry_point in entry_points(group="experimaestro.tokens"):
             entry_point.load().init_registry(self)
 
         # Register the find launcher function if it exists


### PR DESCRIPTION
Listing entry points can be achieved with `importlib.metadata.entry_points` instead of pkg_resources.
This does not trigger a warning anymore.

```sh
uv run --python 3.10 experimaestro --help
```