### PR TITLE
changed to higer level __setattr__

### DIFF
--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -1407,7 +1407,7 @@ class ConfigMixin:
 
         instance = self.__xpm__.fromConfig(context, objects=objects)  # type: ignore
         if keep:
-            instance.__config__ = self
+            object.__setattr__(instance, "__config__", self)
         return instance
 
     def submit(


### PR DESCRIPTION
when inheriting from `nn.Module` setting `instance.__config__ = self`, cause __config__ to be added to the pytorch state dict, which caused state_dict serialization errors
-> changed to higher-level `objects.__setattr__`