### PR TITLE
fix: translate xp path if using SSHStateProvider

### DIFF
--- a/src/experimaestro/scheduler/remote/client.py
+++ b/src/experimaestro/scheduler/remote/client.py
@@ -1533,21 +1533,19 @@ class SSHStateProviderClient(OfflineStateProvider):
         """This is a remote provider"""
         return True
 
-    def get_display_path(self, job: "BaseJob") -> str:
-        """Get the remote path to display/copy for a job
-
-        Translates the local cache path back to the remote path.
+    def translate_path(self, path: "Path") -> str:
+        """Translate the local cache path back to the remote path.
 
         Args:
-            job: Job to get display path for
+            path: Local path to translate
 
         Returns:
             Remote path string
         """
-        if not job.path:
+        if not path:
             return ""
 
-        path_str = str(job.path)
+        path_str = str(path)
         local_cache_str = str(self.local_cache_dir)
 
         # If path is in local cache, translate back to remote path

--- a/src/experimaestro/scheduler/state_provider.py
+++ b/src/experimaestro/scheduler/state_provider.py
@@ -599,6 +599,17 @@ class StateProvider(ABC):
         """
         return False
 
+    def translate_path(self, path: Path) -> str:
+        """Translate a local path to a display path (e.g. remote path)
+
+        Args:
+            path: Local path to translate
+
+        Returns:
+            Path string suitable for display and copying
+        """
+        return str(path)
+
     def get_display_path(self, job: BaseJob) -> str:
         """Get the path to display/copy for a job
 
@@ -611,7 +622,7 @@ class StateProvider(ABC):
         Returns:
             Path string suitable for display and copying
         """
-        return str(job.path) if job.path else ""
+        return self.translate_path(job.path) if job.path else ""
 
 
 # =============================================================================

--- a/src/experimaestro/tests/test_path_translation.py
+++ b/src/experimaestro/tests/test_path_translation.py
@@ -1,5 +1,4 @@
 
-import pytest
 from pathlib import Path
 from experimaestro.scheduler.state_provider import StateProvider
 from experimaestro.scheduler.remote.client import SSHStateProviderClient
@@ -33,7 +32,7 @@ def test_state_provider_translate_path():
     provider = MockStateProvider()
     path = Path("/some/local/path")
     assert provider.translate_path(path) == str(path)
-    
+
     job = MockJob(path)
     assert provider.get_display_path(job) == str(path)
 
@@ -44,20 +43,20 @@ def test_ssh_state_provider_client_translate_path():
     )
     # Set local_cache_dir which is normally set during connect/init
     client.local_cache_dir = Path("/tmp/local/cache")
-    
+
     # Path in local cache should be translated
     local_path = Path("/tmp/local/cache/experiments/exp1/run1")
     expected_remote = "/remote/workspace/experiments/exp1/run1"
     assert client.translate_path(local_path) == expected_remote
-    
+
     # Path NOT in local cache should be returned as-is
     other_path = Path("/some/other/path")
     assert client.translate_path(other_path) == str(other_path)
-    
+
     # Test get_display_path (which now uses translate_path)
     job = MockJob(local_path)
     assert client.get_display_path(job) == expected_remote
-    
+
     # Test for experiments (direct use of translate_path as in experiments.py)
     exp = MockExperiment(local_path)
     assert client.translate_path(exp.workdir) == expected_remote

--- a/src/experimaestro/tests/test_path_translation.py
+++ b/src/experimaestro/tests/test_path_translation.py
@@ -1,0 +1,63 @@
+
+import pytest
+from pathlib import Path
+from experimaestro.scheduler.state_provider import StateProvider
+from experimaestro.scheduler.remote.client import SSHStateProviderClient
+from experimaestro.scheduler.interfaces import BaseJob, BaseExperiment
+
+class MockJob(BaseJob):
+    def __init__(self, path):
+        self.path = path
+
+class MockExperiment(BaseExperiment):
+    def __init__(self, workdir):
+        self.workdir = workdir
+
+class MockStateProvider(StateProvider):
+    def clean_job(self, *args, **kwargs): pass
+    def close(self, *args, **kwargs): pass
+    def get_all_jobs(self, *args, **kwargs): return []
+    def get_current_run(self, *args, **kwargs): return None
+    def get_dependencies_map(self, *args, **kwargs): return {}
+    def get_experiment(self, *args, **kwargs): return None
+    def get_experiment_job_info(self, *args, **kwargs): return None
+    def get_experiment_runs(self, *args, **kwargs): return []
+    def get_experiments(self, *args, **kwargs): return []
+    def get_job(self, *args, **kwargs): return None
+    def get_jobs(self, *args, **kwargs): return []
+    def get_services(self, *args, **kwargs): return []
+    def get_tags_map(self, *args, **kwargs): return {}
+    def kill_job(self, *args, **kwargs): pass
+
+def test_state_provider_translate_path():
+    provider = MockStateProvider()
+    path = Path("/some/local/path")
+    assert provider.translate_path(path) == str(path)
+    
+    job = MockJob(path)
+    assert provider.get_display_path(job) == str(path)
+
+def test_ssh_state_provider_client_translate_path():
+    client = SSHStateProviderClient(
+        host="remote-host",
+        remote_workspace="/remote/workspace"
+    )
+    # Set local_cache_dir which is normally set during connect/init
+    client.local_cache_dir = Path("/tmp/local/cache")
+    
+    # Path in local cache should be translated
+    local_path = Path("/tmp/local/cache/experiments/exp1/run1")
+    expected_remote = "/remote/workspace/experiments/exp1/run1"
+    assert client.translate_path(local_path) == expected_remote
+    
+    # Path NOT in local cache should be returned as-is
+    other_path = Path("/some/other/path")
+    assert client.translate_path(other_path) == str(other_path)
+    
+    # Test get_display_path (which now uses translate_path)
+    job = MockJob(local_path)
+    assert client.get_display_path(job) == expected_remote
+    
+    # Test for experiments (direct use of translate_path as in experiments.py)
+    exp = MockExperiment(local_path)
+    assert client.translate_path(exp.workdir) == expected_remote

--- a/src/experimaestro/tui/widgets/experiments.py
+++ b/src/experimaestro/tui/widgets/experiments.py
@@ -97,7 +97,7 @@ class ExperimentsList(Widget):
             None,
         )
         if exp_info and exp_info.workdir:
-            path_str = str(exp_info.workdir)
+            path_str = self.state_provider.translate_path(exp_info.workdir)
             if copy(path_str):
                 self.notify(f"Path copied: {path_str}", severity="information")
             else:


### PR DESCRIPTION
This ends fixing https://github.com/experimaestro/experimaestro-python/issues/213 by providing xp path translation when using SSHStateProvider.

Summary of Changes

   1. Core API: Added `translate_path(path: Path) -> str` to the StateProvider base class. This provides a standard way to
      convert internal filesystem paths into user-facing display paths.
   2. Remote Support: Implemented translate_path in `SSHStateProviderClient`. It now automatically detects if a path resides within the local SSH cache and translates it back to the corresponding path in the remote_workspace.
   3. TUI Fix: Updated the ExperimentsList widget's action_copy_path to use this translation service. This fixes the bug
      where pressing 'f' would copy a temporary local cache path instead of the actual remote path.
   4. Consistency: Refactored `get_display_path` (used by Tasks) to use this new centralized translation logic, ensuring
      consistent behavior across all TUI components.
   5. Validation: Added unit tests in test_path_translation.py covering both local and remote path translation scenarios.

  These changes ensure that "Copy Path" always returns a meaningful path to the user, regardless of whether the experiment  is running locally or on a remote cluster.