### PR TITLE
feat: xpmconfig attribute

### DIFF
--- a/docs/source/experiments/config.md
+++ b/docs/source/experiments/config.md
@@ -947,6 +947,54 @@ class LeafImpl(Leaf, BaseImpl):
     pass
 ```
 
+(accessing-configuration)=
+## Accessing configuration from instances
+
+When a configuration is instantiated (via `config.instance()`), it is often
+useful to access the original configuration object from the resulting instance.
+This is made possible by the `xpmconfig` property.
+
+By default, `config.instance()` tracks the original configuration. This
+behavior can be controlled with the `keep` parameter (which defaults to `True`).
+
+```python
+config = MyModel.C(gamma=0.1)
+instance = config.instance()
+
+# Access the original configuration
+assert instance.xpmconfig is config
+```
+
+### Recursive tracking
+
+Configuration tracking is recursive. If a configuration contains other
+configuration objects as parameters, those sub-configurations are also
+instantiated, and their instances will also have their `xpmconfig` property
+set to the corresponding original sub-configuration.
+
+```python
+sub_config = SubModel.C(x=1)
+main_config = MainModel.C(sub=sub_config)
+instance = main_config.instance()
+
+# Recursive tracking
+assert instance.sub.xpmconfig is sub_config
+```
+
+### Unified API
+
+The `xpmconfig` property is available on both configuration objects and
+their instances. When called on a configuration object, it returns
+the object itself. This allows configuration and instances to be used
+interchangeably in many contexts.
+
+```python
+def process(obj):
+    # Works whether obj is a Config or an instantiated value
+    config = obj.xpmconfig
+    print(f"Processing with config: {config}")
+```
+
 (instance-based-configurations)=
 ## Instance-based configurations
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,12 +1,73 @@
-# Introduction
+# Experimaestro 
 
-```{toctree}
----
-maxdepth: 1
-caption: "Getting Started"
----
-tutorial
-```
+[![GitHub Release](https://img.shields.io/github/v/release/experimaestro/experimaestro-python)](https://github.com/experimaestro/experimaestro-python)
+
+## Introduction
+
+Experimaestro is a versatile tool for designing and managing complex workflows.
+It enables the definition of tasks and their dependencies, ensuring orderly
+execution within a workflow. Key features of Experimaestro include:
+
+- **Task Automation and Caching**: Automates repetitive tasks, facilitating large-scale
+  experiments, especially useful when varying parameters or datasets.
+- **Extensibility**: Designed for flexibility, Experimaestro can easily be integrated with
+  existing libraries, serving the diverse needs of data science and research.
+- **Reproducibility**: Maintains comprehensive records of experiments, including
+  parameters and environments, supporting the essential research principle of
+  reproducibility.
+- **User Interface**: Offers a user interface for workflow management and
+  visualization, complementing its primary back-end functionality.
+
+
+## Difference with Other Projects
+
+Experimaestro differentiates itself from traditional job scheduling software
+like [OAR](https://oar.imag.fr) and [Slurm](https://slurm.schedmd.com), which
+focus more on resource allocation than on managing experimental workflows. It
+also stands apart from other experiment management tools like
+[Comet](https://www.comet.ml), [Sacred](https://github.com/IDSIA/sacred),
+[FGLab](https://github.com/Kaixhin/FGLab), and
+[Sumatra](http://neuralensemble.org/sumatra/). For instance, Comet emphasizes
+collaboration and note-taking for machine learning experiments but is not
+open-source and focuses on single-shot experiments. Sumatra and FGLab, based on
+parameter files, offer less flexibility. Sacred, though open-source and allowing
+for pre-processing steps, doesn't support the construction of complex
+experimental plans like Experimaestro.
+
+Experimaestro's distinct features include:
+
+1. **Comprehensive Task Composition**: It allows for the composition of types
+   and tasks within an experimental plan.
+2. **Parameter Monitoring**: Offers a clear method to monitor experimental
+   parameters using tags.
+3. **Automated Output Organization**: Efficiently manages task outputs in the
+   file system, simplifying result storage.
+4. **Imperative Experiment Definition**: Unlike other tools that define
+   experiments declaratively, Experimaestro adopts an imperative approach,
+   enhancing flexibility in complex experimental planning.
+
+## Guide to the Documentation
+
+**🏁 Getting Started**
+If you are new to the project, start with the [Tutorial](./tutorial.md). It walks you through setting up your first workspace and running a basic experiment: training a CNN on MNIST.
+
+**🧪 Building Experiments**
+Learn how to define your workflow:
+  - [Configurations](./experiments/config.md): The heart of Experimaestro. Define parameters, nested structures, and value
+    classes.
+  - [Tasks](./experiments/task.md): Define the execution logic and manage dependencies.
+  - Experimental [Plans](./experiments/plan.md): Compose tasks into complex matrices and track them using tags.
+
+**⚙️ Execution & Infrastructure**
+Control where and how your code runs:
+  - [Launchers](./launchers/index.md): Manage execution environments (Direct, Slurm).
+  - [Connectors](./connectors/index.md): Abstract file access and command execution (Local, SSH).
+
+**🛠️ Advanced Tools**
+  - [Jupyter Integration](./jupyter.md): Interact with your experiments from notebooks.
+  - [API Reference](./api/index.md): Deep dive into the classes and methods.
+
+# Documentation Outline
 
 ```{toctree}
 ---
@@ -71,65 +132,6 @@ caption: "Development"
 development/experiment
 development/api
 ```
-
-Experimaestro is a versatile tool for designing and managing complex workflows.
-It enables the definition of tasks and their dependencies, ensuring orderly
-execution within a workflow. Key features of Experimaestro include:
-
-- **Task Automation**: Automates repetitive tasks, facilitating large-scale
-  experiments, especially useful when varying parameters or datasets.
-- **Extensibility**: Designed for flexibility, Experimaestro can easily be integrated with
-  existing libraries, serving the diverse needs of data science and research.
-- **Reproducibility**: Maintains comprehensive records of experiments, including
-  parameters and environments, supporting the essential research principle of
-  reproducibility.
-- **User Interface**: Offers a user interface for workflow management and
-  visualization, complementing its primary back-end functionality.
-
-## Difference with Other Projects
-
-Experimaestro differentiates itself from traditional job scheduling software
-like [OAR](https://oar.imag.fr) and [Slurm](https://slurm.schedmd.com), which
-focus more on resource allocation than on managing experimental workflows. It
-also stands apart from other experiment management tools like
-[Comet](https://www.comet.ml), [Sacred](https://github.com/IDSIA/sacred),
-[FGLab](https://github.com/Kaixhin/FGLab), and
-[Sumatra](http://neuralensemble.org/sumatra/). For instance, Comet emphasizes
-collaboration and note-taking for machine learning experiments but is not
-open-source and focuses on single-shot experiments. Sumatra and FGLab, based on
-parameter files, offer less flexibility. Sacred, though open-source and allowing
-for pre-processing steps, doesn't support the construction of complex
-experimental plans like Experimaestro.
-
-Experimaestro's distinct features include:
-
-1. **Comprehensive Task Composition**: It allows for the composition of types
-   and tasks within an experimental plan.
-2. **Parameter Monitoring**: Offers a clear method to monitor experimental
-   parameters using tags.
-3. **Automated Output Organization**: Efficiently manages task outputs in the
-   file system, simplifying result storage.
-4. **Imperative Experiment Definition**: Unlike other tools that define
-   experiments declaratively, Experimaestro adopts an imperative approach,
-   enhancing flexibility in complex experimental planning.
-
-## Outline of the documentation
-
-### Tutorial
-
-You can follow the [tutorial](./tutorial.md)
-
-### Experimental plan
-
-An experimental plan is based on [configuration and tasks](./experiments/config.md), and define which tasks should be run with which parameters. Within an experiment, [tags](./experiments/plan.md#tags) can be used to track experimental parameters.
-
-### Connectors
-
-A [connector](./connectors/index.md) allow to specify how to access files on the computer where a task will be launched, and how to run processes on this computer. Two basic connectors exist, for localhost and SSH accesses (_alpha_).
-
-### Launcher
-
-A [launcher](./launchers/index.md) specifies how a given task can be run. The most basic method is direct execution, but experimaestro can launch and monitor oar (_planned_) and slurm (_planned_) jobs.
 
 
 :::{note}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,23 +1,26 @@
-# Experimaestro 
+# Experimaestro
 
 [![GitHub Release](https://img.shields.io/github/v/release/experimaestro/experimaestro-python)](https://github.com/experimaestro/experimaestro-python)
 
-## Introduction
+**Experimaestro** is a Python framework designed for researchers and engineers who need to manage complex, large-scale experimental workflows without losing track of reproducibility.
 
-Experimaestro is a versatile tool for designing and managing complex workflows.
-It enables the definition of tasks and their dependencies, ensuring orderly
-execution within a workflow. Key features of Experimaestro include:
+Unlike traditional schedulers, Experimaestro focuses on the **experimental logic**: how configurations relate to each other and how results are organized.
 
-- **Task Automation and Caching**: Automates repetitive tasks, facilitating large-scale
-  experiments, especially useful when varying parameters or datasets.
-- **Extensibility**: Designed for flexibility, Experimaestro can easily be integrated with
-  existing libraries, serving the diverse needs of data science and research.
-- **Reproducibility**: Maintains comprehensive records of experiments, including
-  parameters and environments, supporting the essential research principle of
-  reproducibility.
-- **User Interface**: Offers a user interface for workflow management and
-  visualization, complementing its primary back-end functionality.
+![Experimaestro TUI](./img/tui-jobs.png)
 
+## Why Experimaestro?
+
+Experimaestro solves common pain points in research workflows by providing:
+
+- **🚀 Configuration-as-Code:** Define your experiments using strongly-typed Python objects. Forget about fragile JSON/YAML files; benefit from IDE autocompletion, type checking, and recursive parameter management.
+
+- 🛡️ **Deduplication & Reproducibility**: Every task is assigned a unique identifier based on its parameters. If you try to run the same experiment twice, Experimaestro knows—ensuring you never waste compute time on results you already have.
+
+- 📁 **Organized by Design** Results are automatically cached in a predictable directory structure derived from task identifiers. No more "results_v2_final_fixed.pt"—your file system stays as clean as your code.
+
+- 🏗️ **Built-in Scalability** Seamlessly transition from local testing to high-performance clusters. Use **Connectors** (Local, SSH) and **Launchers** (Direct, Slurm) to run the same experimental code across different environments.
+
+---
 
 ## Difference with Other Projects
 
@@ -67,7 +70,7 @@ Control where and how your code runs:
   - [Jupyter Integration](./jupyter.md): Interact with your experiments from notebooks.
   - [API Reference](./api/index.md): Deep dive into the classes and methods.
 
-# Documentation Outline
+# Detailed Outline
 
 ```{toctree}
 ---

--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -1660,7 +1660,7 @@ class ConfigInformation:
             context: ConfigWalkContext,
             *,
             objects: ObjectStore = None,
-            keep: bool = False,
+            keep: bool = True,
         ):
             super().__init__(context)
             self.objects = ObjectStore() if objects is None else objects
@@ -1702,7 +1702,7 @@ class ConfigInformation:
         context: ConfigWalkContext,
         *,
         objects: ObjectStore = None,
-        keep: bool = False,
+        keep: bool = True,
     ):
         """Generate an instance given the current configuration"""
 

--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -601,9 +601,9 @@ class ConfigInformation:
                                         logging.warning("Ignoring %s", k)
                                     value = argument.generator(self.context, config)
                                 else:
-                                    assert False, (
-                                        "generator has either two parameters (context and config), or none"
-                                    )
+                                    assert (
+                                        False
+                                    ), "generator has either two parameters (context and config), or none"
                             config.__xpm__.set(k, value, bypass=True)
                         else:
                             value = config.__xpm__.values.get(k)
@@ -975,9 +975,9 @@ class ConfigInformation:
             be able to run concurrently with the producing task.
         """
         assert not isinstance(config, Task), "Cannot set a dependency on a task"
-        assert isinstance(config, ConfigMixin), (
-            "Only configurations can be marked as dependent on a task"
-        )
+        assert isinstance(
+            config, ConfigMixin
+        ), "Only configurations can be marked as dependent on a task"
 
         if config.__xpm__.task is self.pyobject:
             return
@@ -1255,9 +1255,9 @@ class ConfigInformation:
         :return: a Config object, its instance or a tuple (instance, init_tasks) is return_tasks is True
         """
         # Load
-        assert not (as_instance and return_tasks), (
-            "Cannot set as_instance and return_tasks to True"
-        )
+        assert not (
+            as_instance and return_tasks
+        ), "Cannot set as_instance and return_tasks to True"
         if callable(path):
             data_loader = path
         else:
@@ -1588,9 +1588,9 @@ class ConfigInformation:
                     # Unwrap the value if needed
                     setattr(o, name, v)
 
-                    assert getattr(o, name) is v, (
-                        f"Problem with deserialization {name} of {o.__class__}"
-                    )
+                    assert (
+                        getattr(o, name) is v
+                    ), f"Problem with deserialization {name} of {o.__class__}"
                 else:
                     o.__xpm__.set(name, v, bypass=True)
 
@@ -1655,9 +1655,16 @@ class ConfigInformation:
         return o
 
     class FromPython(ConfigWalk):
-        def __init__(self, context: ConfigWalkContext, *, objects: ObjectStore = None):
+        def __init__(
+            self,
+            context: ConfigWalkContext,
+            *,
+            objects: ObjectStore = None,
+            keep: bool = False,
+        ):
             super().__init__(context)
             self.objects = ObjectStore() if objects is None else objects
+            self.keep = keep
 
         def preprocess(self, config: "Config"):
             if self.objects.is_constructed(id(config)):
@@ -1684,17 +1691,26 @@ class ConfigInformation:
             # Call __post_init__
             stub.__post_init__()
 
+            if self.keep:
+                object.__setattr__(stub, "__config__", config)
+
             self.objects.set_constructed(id(config))
             return stub
 
-    def fromConfig(self, context: ConfigWalkContext, *, objects: ObjectStore = None):
+    def fromConfig(
+        self,
+        context: ConfigWalkContext,
+        *,
+        objects: ObjectStore = None,
+        keep: bool = False,
+    ):
         """Generate an instance given the current configuration"""
 
         # Validate and seal
         self.validate()
         self.seal(context)
 
-        processor = ConfigInformation.FromPython(context, objects=objects)
+        processor = ConfigInformation.FromPython(context, objects=objects, keep=keep)
         last_object = processor(self.pyobject)
 
         return last_object
@@ -2001,14 +2017,11 @@ class ConfigMixin:
 
             context = EmptyContext()
         else:
-            assert isinstance(context, ConfigWalkContext), (
-                f"{context.__class__} is not an instance of ConfigWalkContext"
-            )
+            assert isinstance(
+                context, ConfigWalkContext
+            ), f"{context.__class__} is not an instance of ConfigWalkContext"
 
-        instance = self.__xpm__.fromConfig(context, objects=objects)  # type: ignore
-        if keep:
-            object.__setattr__(instance, "__config__", self)
-        return instance
+        return self.__xpm__.fromConfig(context, objects=objects, keep=keep)  # type: ignore
 
     def submit(
         self,
@@ -2164,13 +2177,31 @@ class Config:
         result: dict[str, SerializedPath] = {}
         for argument, value in self.__xpm__.xpmvalues():
             if argument.is_data and value is not None:
-                assert isinstance(value, Path), (
-                    f"Data arguments should be paths (type is {type(value)})"
-                )
+                assert isinstance(
+                    value, Path
+                ), f"Data arguments should be paths (type is {type(value)})"
                 result[argument.name] = context.serialize(
                     context.var_path + [argument.name], value, self
                 )
         return result
+
+    @property
+    def xpmconfig(self) -> T:
+        """Returns the original configuration for this instance.
+
+        This property is available if the instance was created with
+        `keep=True` (which is the default for `Config.instance`).
+        If called on a configuration object, it returns the object itself.
+        """
+        if isinstance(self, ConfigMixin):
+            return self  # type: ignore
+
+        if hasattr(self, "__config__"):
+            return getattr(self, "__config__")
+        raise AttributeError(
+            f"Object of type {type(self)} has no configuration tracked. "
+            "Ensure it was instantiated with .instance(keep=True)"
+        )
 
     @classproperty
     def XPMConfig(cls):

--- a/src/experimaestro/tests/test_xpmconfig.py
+++ b/src/experimaestro/tests/test_xpmconfig.py
@@ -1,0 +1,41 @@
+from experimaestro import Config, Param
+import pytest
+
+class SubModule(Config):
+    y: Param[int]
+
+class MainModule(Config):
+    sub: Param[SubModule]
+
+def test_xpmconfig_recursive():
+    """Test that xpmconfig is available recursively on instantiated objects"""
+    config = MainModule.C(sub=SubModule.C(y=20))
+    instance = config.instance(keep=True)
+
+    # Check root
+    assert instance.xpmconfig is config
+    assert isinstance(instance.xpmconfig, MainModule.XPMConfig)
+
+    # Check sub-object (recursive tracking)
+    assert instance.sub.xpmconfig is config.sub
+    assert isinstance(instance.sub.xpmconfig, SubModule.XPMConfig)
+    assert instance.sub.xpmconfig.y == 20
+
+def test_xpmconfig_on_config():
+    """Test that xpmconfig returns the object itself when called on a configuration"""
+    config = SubModule.C(y=10)
+    assert config.xpmconfig is config
+
+def test_xpmconfig_no_keep():
+    """Test that xpmconfig raises AttributeError if keep=False was used"""
+    config = SubModule.C(y=10)
+    instance = config.instance(keep=False)
+
+    with pytest.raises(AttributeError, match="has no configuration tracked"):
+        _ = instance.xpmconfig
+
+def test_xpmconfig_default_behavior():
+    """Test that xpmconfig is available by default (keep=True is default)"""
+    config = SubModule.C(y=10)
+    instance = config.instance()
+    assert instance.xpmconfig is config


### PR DESCRIPTION
Proposed improvement to have a solid instance.xpmconfig 

   - Recursive keep=True: Instantiated objects now track their original configuration recursively.
   - xpmconfig Property: Added a standardized property to the Config base class to access this configuration.
   - Improved API: xpmconfig returns self on configuration objects, making them interchangeable in many contexts.
   
  (I would also propose to have it to true by default, leaving possible to drop it)