### PR TITLE
fix: double check files for task status

### DIFF
--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -971,13 +971,14 @@ class ConfigInformation:
 
             color = "white"
             if self.job.workspace is not None:
-                if self.job.donepath.is_file():
-                    color = "light_green"
-                    cprint(f"[done] {s}", color, file=sys.stderr)
-                elif self.job.failedpath.is_file():
+                self.job.load_from_disk()
+                if self.job.state.is_error():
                     color = "light_red"
                     cprint(f"[failed] {s}", color, file=sys.stderr)
-                elif self.job.pidpath.is_file():
+                elif self.job.state.finished():
+                    color = "light_green"
+                    cprint(f"[done] {s}", color, file=sys.stderr)
+                elif self.job.state.running():
                     color = "blue"
                     cprint(f"[running] {s}", color, file=sys.stderr)
                 else:

--- a/src/experimaestro/scheduler/interfaces.py
+++ b/src/experimaestro/scheduler/interfaces.py
@@ -1211,7 +1211,8 @@ class BaseJob:
 
         # Check PID file for running state using launcher-independent
         # Process abstraction (handles local, SSH, SLURM, etc.)
-        elif self.pidfile.exists():
+        # ONLY check if the job is not already finished, to avoid zombie pidfiles
+        elif self.pidfile.exists() and not self.state.finished():
             try:
                 from experimaestro.connectors import Process
                 from experimaestro.connectors.local import LocalConnector

--- a/src/experimaestro/scheduler/interfaces.py
+++ b/src/experimaestro/scheduler/interfaces.py
@@ -1223,6 +1223,15 @@ class BaseJob:
                     self.set_state(JobState.RUNNING, loading=True)
             except Exception:
                 pass
+        else:
+            # If status.json says it's finished but marker files and PID files are missing,
+            # the job directory is likely corrupted/purged. Override to WAITING.
+            if self.state.finished():
+                logger.warning(
+                    "Job %s marked as %s in status.json but marker files are missing. Resetting to WAITING.",
+                    self.identifier, self.state
+                )
+                self.set_state(JobState.WAITING, loading=True)
 
     def _load_from_status_dict(self, status_dict: Dict[str, Any]) -> None:
         """Load fields from status.json dictionary

--- a/src/experimaestro/scheduler/interfaces.py
+++ b/src/experimaestro/scheduler/interfaces.py
@@ -398,6 +398,9 @@ class JobFailureStatus(enum.Enum):
     #: Job rejected due to time limit (e.g., requested time exceeds partition max)
     REJECTED_TIMELIMIT = 5
 
+    #: Job output marker missing (probably purged by cluster)
+    MISSING_OUTPUTS = 7
+
     #: Job rejected for other reasons (e.g., invalid partition, resource constraints)
     REJECTED_OTHER = 6
 
@@ -1226,13 +1229,13 @@ class BaseJob:
                 pass
         else:
             # If status.json says it's finished but marker files and PID files are missing,
-            # the job directory is likely corrupted/purged. Override to WAITING.
+            # the job directory is likely corrupted/purged. Override to ERROR.
             if self.state.finished():
                 logger.warning(
-                    "Job %s marked as %s in status.json but marker files are missing. Resetting to WAITING.",
+                    "Job %s marked as %s in status.json but marker files are missing. Resetting to ERROR.",
                     self.identifier, self.state
                 )
-                self.set_state(JobState.WAITING, loading=True)
+                self.set_state(JobStateError(JobFailureStatus.MISSING_OUTPUTS), loading=True)
 
     def _load_from_status_dict(self, status_dict: Dict[str, Any]) -> None:
         """Load fields from status.json dictionary


### PR DESCRIPTION
## Fix: Reset state to WAITING when job marker files are missing
  
  ### Description
  
  This PR fixes an issue where the scheduler would incorrectly trust a stale  status.json  indicating a job was  DONE 
  (or  ERROR ), even if the actual  .done  or  .failed  marker files (and job outputs) were deleted from the          
  directory.
  
  ### Why this happens
  
  On HPC clusters with automated file purging (like Lustre's Robinhood) or during manual cleanups, job output files   
  and marker files ( .done / .failed ) might be deleted because they are considered old. However, because             
  experimaestro  reads  .experimaestro/status.json  on startup, the  status.json  file's access time is continually   
  refreshed and avoids deletion.
  
  Previously,  Job.load_from_disk()  would load the  DONE  state from  status.json , check if the  .done  file        
  existed, and if it didn't, it would silently leave the state as  DONE  instead of reverting it. This resulted in    
  "ghost completions", where downstream dependencies (like  Learner ) were launched on completely empty job           
  directories, inevitably crashing with  FileNotFoundError .
  
  ### Changes
  
  • Updated  Job.load_from_disk()  in  experimaestro/scheduler/interfaces.py .
  • Added a fallback in the state-checking logic: if  status.json  claims the job is finished, but both the marker    
  files and PID files are missing from the disk, we now log a warning and forcefully reset the job state to  WAITING .
  • This ensures the scheduler accurately reflects the state on disk and properly re-runs purged/missing jobs.    