### PR TITLE
fix: don't tag GridSearch Param if unique value in the Grid

### DIFF
--- a/src/experimaestro/experiments/grid.py
+++ b/src/experimaestro/experiments/grid.py
@@ -296,8 +296,9 @@ def generate_grid(cfg: Any) -> Tuple[List[Any], List[dict]]:
     for combination in grid_combinations:
         cfg_tags = {}
         new_cfg = copy.deepcopy(base_cfg)
-        for path, value in zip(param_paths, combination):
-            cfg_tags[path] = value
+        for i, (path, value) in enumerate(zip(param_paths, combination)):
+            if len(value_options[i]) > 1:
+                cfg_tags[path] = value
             set_nested_attr(new_cfg, path, value)
 
         # Convert any remaining single-value GenericParams to scalars

--- a/src/experimaestro/tests/test_grid.py
+++ b/src/experimaestro/tests/test_grid.py
@@ -114,7 +114,17 @@ def test_unique_value_in_tags():
 
     configs, tags = generate_grid(cfg)
     assert len(configs) == 1
-    assert tags[0]["lr"] == 0.1
-    assert tags[0]["batch_size"] == 32
+    assert tags[0] == {}
+
+    # Test that multi-value params are tagged while single-value params in the same grid are not
+    cfg_multi = MyConfig(id="test", lr=[0.1, 0.01], batch_size=32)
+    cfg_multi.lr = GenericParams.from_any(cfg_multi.lr)
+    cfg_multi.batch_size = GenericParams.from_any(cfg_multi.batch_size)
+
+    configs_multi, tags_multi = generate_grid(cfg_multi)
+    assert len(configs_multi) == 2
+    assert tags_multi[0] == {"lr": 0.1}
+    assert tags_multi[1] == {"lr": 0.01}
+
 
 

--- a/src/experimaestro/tests/test_grid_validation.py
+++ b/src/experimaestro/tests/test_grid_validation.py
@@ -79,7 +79,22 @@ def test_unique_value_in_tags_from_validation():
     configs, tags = generate_grid(cfg)
 
     assert len(configs) == 1
-    assert tags[0] == {"lr": 0.05, "sub.value": 10}
+    assert tags[0] == {}
+
+    # Test with multi-value param
+    data_multi = {
+        "id": "test",
+        "lr": [0.05, 0.1],
+        "sub": {"value": 10}
+    }
+
+    cfg_multi = validate_attrs(MainConfig, data_multi)
+    configs_multi, tags_multi = generate_grid(cfg_multi)
+
+    assert len(configs_multi) == 2
+    assert tags_multi[0] == {"lr": 0.05}
+    assert tags_multi[1] == {"lr": 0.1}
+
 
 
 def test_unrecognized_key_in_validation():


### PR DESCRIPTION
As we now can have many GridSearch Params in a config, it is better by default to tag them only if we are actually grid-searching on them.  