### PR TITLE
feat(scheduler): report completed jobs from auxiliary folders during dry-run simulation

### DIFF
--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -982,8 +982,17 @@ class ConfigInformation:
                     color = "blue"
                     cprint(f"[running] {s}", color, file=sys.stderr)
                 else:
-                    color = "light_blue"
-                    cprint(f"[not run] {s}", color, file=sys.stderr)
+                    folder_ws_name = self.job.find_done_in_folders()
+                    if folder_ws_name:
+                        color = "light_green"
+                        cprint(
+                            f"[done](will copy from {folder_ws_name}) {s}",
+                            color,
+                            file=sys.stderr,
+                        )
+                    else:
+                        color = "light_blue"
+                        cprint(f"[not run] {s}", color, file=sys.stderr)
 
                 if launcher:
                     cprint(f"   [Launcher] {launcher}", color, file=sys.stderr)

--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -986,47 +986,51 @@ class ConfigInformation:
                 cprint(f"[prepare: nothing to do] {s}", "white", file=sys.stderr)
             print(file=sys.stderr)  # noqa: T201
         else:
-            # Show a warning
-            if run_mode == RunMode.GENERATE_ONLY:
-                experiment.CURRENT.prepare(self.job)
+            self._simulate_submit(run_mode, launcher)
 
-            # Check if job is done
-            tags = ", ".join(f"{k}={v}" for k, v in self.job.config.tags().items())
-            s = f"""Simulating {self.job.relpath} {f"({tags})" if tags else ""}"""
+    def _simulate_submit(self, run_mode, launcher):
+        from experimaestro.scheduler import experiment
+        from experimaestro.scheduler.workspace import RunMode
 
-            color = "white"
-            if self.job.workspace is not None:
-                self.job.load_from_disk()
-                if self.job.state.is_error():
-                    color = "light_red"
-                    cprint(f"[failed] {s}", color, file=sys.stderr)
-                elif self.job.state.finished():
-                    color = "light_green"
-                    cprint(f"[done] {s}", color, file=sys.stderr)
-                elif self.job.state.running():
-                    color = "blue"
-                    cprint(f"[running] {s}", color, file=sys.stderr)
-                else:
-                    folder_ws_name = self.job.find_done_in_folders()
-                    if folder_ws_name:
-                        color = "light_green"
-                        cprint(
-                            f"[done](will copy from {folder_ws_name}) {s}",
-                            color,
-                            file=sys.stderr,
-                        )
-                    else:
-                        color = "light_blue"
-                        cprint(f"[not run] {s}", color, file=sys.stderr)
+        # Show a warning
+        if run_mode == RunMode.GENERATE_ONLY:
+            experiment.CURRENT.prepare(self.job)
 
-                if launcher:
-                    cprint(f"   [Launcher] {launcher}", color, file=sys.stderr)
+        # Check if job is done
+        tags = ", ".join(f"{k}={v}" for k, v in self.job.config.tags().items())
+        s = f"""Simulating {self.job.relpath} {f"({tags})" if tags else ""}"""
 
-                if not self.job.dependencies:
-                    cprint("   [No dependencies]", color, file=sys.stderr)
+        color = "white"
+        if self.job.workspace is not None:
+            self.job.load_from_disk()
+            if self.job.state.is_error():
+                color = "light_red"
+                cprint(f"[failed] {s}", color, file=sys.stderr)
+            elif self.job.state.finished():
+                color = "light_green"
+                cprint(f"[done] {s}", color, file=sys.stderr)
+            elif self.job.state.running():
+                color = "blue"
+                cprint(f"[running] {s}", color, file=sys.stderr)
+            elif folder_ws_name := self.job.find_done_in_folders():
+                color = "light_green"
+                cprint(
+                    f"[done](will copy from {folder_ws_name}) {s}",
+                    color,
+                    file=sys.stderr,
+                )
+            else:
+                color = "light_blue"
+                cprint(f"[not run] {s}", color, file=sys.stderr)
 
-                for dep in self.job.dependencies:
-                    cprint(f"   [Dependency] {dep}", color, file=sys.stderr)
+            if launcher:
+                cprint(f"   [Launcher] {launcher}", color, file=sys.stderr)
+
+            if not self.job.dependencies:
+                cprint("   [No dependencies]", color, file=sys.stderr)
+
+            for dep in self.job.dependencies:
+                cprint(f"   [Dependency] {dep}", color, file=sys.stderr)
 
                 print(file=sys.stderr)  # noqa: T201
 

--- a/src/experimaestro/scheduler/folders.py
+++ b/src/experimaestro/scheduler/folders.py
@@ -365,6 +365,40 @@ def wait_for_pending(timeout: Optional[float] = None) -> bool:
     return _WORKER.wait(timeout=timeout)
 
 
+def find_in_folders(
+    rel: Path,
+    folders: list[FolderSettings],
+) -> Optional[tuple[FolderSettings, Path]]:
+    """Look up a relative job path (<task_id>/<hash>) across attached folders.
+
+    Returns the matching (FolderSettings, job_path) tuple for the first
+    folder containing the job directory, or None if not found.
+    """
+    for folder in folders:
+        src = folder.path / "jobs" / rel
+        if src.exists():
+            return folder, src
+    return None
+
+
+def get_folder_workspace_name(folder: FolderSettings) -> str:
+    """Resolve the display workspace name for a FolderSettings instance.
+
+    Returns the registered workspace id if folder.path matches a workspace
+    in settings.workspaces, otherwise falls back to folder.path.name.
+    """
+    try:
+        from experimaestro.settings import get_settings
+
+        folder_resolved = folder.path.expanduser().resolve()
+        for ws in get_settings().workspaces:
+            if Path(ws.path).expanduser().resolve() == folder_resolved:
+                return ws.id
+    except Exception:
+        pass
+    return folder.path.name or str(folder.path)
+
+
 def recover_from_folders(
     rel: Path,
     primary_jobs: Path,
@@ -384,9 +418,10 @@ def recover_from_folders(
         return dest
 
     for folder in folders:
-        src = folder.path / "jobs" / rel
-        if not src.exists():
+        match = find_in_folders(rel, [folder])
+        if match is None:
             continue
+        _, src = match
 
         tmp = dest.parent / f".tmp.{dest.name}"
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/src/experimaestro/scheduler/jobs.py
+++ b/src/experimaestro/scheduler/jobs.py
@@ -331,6 +331,30 @@ class Job(BaseJob, Resource):
         if self.scheduler:
             self.scheduler.notify_job_state(self)
 
+    def find_done_in_folders(self) -> Optional[str]:
+        """Check if job has finished in any attached workspace folder.
+
+        Uses shared find_in_folders detection. Returns the workspace/folder
+        display name if found done, else None.
+        """
+        if not self.workspace or not self.workspace.folders:
+            return None
+
+        from experimaestro.scheduler.folders import (
+            find_in_folders,
+            get_folder_workspace_name,
+        )
+        from experimaestro.scheduler.interfaces import JobState
+
+        match = find_in_folders(Path(self.relpath), self.workspace.folders)
+        if match is not None:
+            folder, src = match
+            marker_state = JobState.from_path(src, self.name)
+            if marker_state == JobState.DONE:
+                return get_folder_workspace_name(folder)
+
+        return None
+
     @cached_property
     def python_path(self) -> Iterator[str]:
         """Returns an iterator over python path"""

--- a/src/experimaestro/tests/test_folders.py
+++ b/src/experimaestro/tests/test_folders.py
@@ -7,13 +7,12 @@ trigger) is exercised by the existing job lifecycle tests by virtue of
 ``Workspace.folders`` defaulting to empty.
 """
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 
 import pytest
 
+from experimaestro import Param, RunMode, Task
 from experimaestro.locking import create_file_lock
 from experimaestro.scheduler.folders import (
     _archive_job,
@@ -375,3 +374,67 @@ class TestSettingsDeprecation:
         assert len(folders) == 1
         assert folders[0].mode == FolderMode.USE
         assert folders[0].path == other
+
+
+class TestDryRunFolderLookup:
+    """Test folder lookup in dry-run mode."""
+
+    def test_find_in_folders_helper(self, tmp_path: Path):
+        from experimaestro.scheduler.folders import (
+            find_in_folders,
+            get_folder_workspace_name,
+        )
+
+        backup_root = tmp_path / "backup"
+        job_src = backup_root / "jobs" / TASK_ID / JOB_ID
+        job_src.mkdir(parents=True)
+        (job_src / "MyTask.done").write_text("")
+
+        folder = FolderSettings(path=backup_root, mode=FolderMode.USE)
+        rel = Path(TASK_ID) / JOB_ID
+
+        match = find_in_folders(rel, [folder])
+        assert match is not None
+        assert match[0] == folder
+        assert match[1] == job_src
+
+        ws_name = get_folder_workspace_name(folder)
+        assert ws_name == "backup"
+
+    def test_dry_run_displays_will_copy_from_folder(self, tmp_path: Path, capsys):
+        from experimaestro.scheduler.jobs import Job
+        from experimaestro.scheduler.workspace import Workspace
+        from experimaestro.settings import Settings, WorkspaceSettings
+
+        # Create external folder with completed job
+        backup_root = tmp_path / "shared_ws"
+        folder = FolderSettings(path=backup_root, mode=FolderMode.USE)
+
+        class SimpleTask(Task):
+            x: Param[int]
+
+            def execute(self):
+                pass
+
+        task = SimpleTask.C(x=42)
+
+        # Create primary workspace configured with the folder
+        primary_root = tmp_path / "primary"
+        ws_settings = WorkspaceSettings(
+            id="primary",
+            path=primary_root,
+            folders=[folder],
+        )
+        settings = Settings(workspaces=[ws_settings])
+        workspace = Workspace(settings, ws_settings, launcher=None)
+
+        job = Job(task, workspace=workspace)
+        ext_job_dir = backup_root / "jobs" / job.relpath
+        ext_job_dir.mkdir(parents=True)
+        (ext_job_dir / f"{job.name}.done").write_text("")
+
+        with workspace:
+            task.submit(run_mode=RunMode.DRY_RUN)
+
+        captured = capsys.readouterr()
+        assert "[done](will copy from shared_ws)" in captured.err


### PR DESCRIPTION

## Summary

When simulating task execution (e.g. `DRY_RUN` mode), jobs missing from the primary workspace were previously reported 
as `[not run]`, even if they were already completed in an attached auxiliary workspace folder (`mode: use`, `backup`, or 
`move`). 

This PR refactors folder detection into a shared helper routine and updates `dry_run` simulation logging to report:    
```text
[done](will copy from WS_NAME) Simulating <task_relpath> ...

## Changes

• experimaestro.scheduler.folders:
    • Extracted find_in_folders(rel, folders) helper to share candidate job directory lookup between normal-mode recovery
    and dry-run simulation.
    • Added get_folder_workspace_name(folder) to resolve workspace IDs from settings.workspaces (or fall back to         
    directory basenames).
    • Refactored recover_from_folders() to consume find_in_folders().
• experimaestro.scheduler.jobs:
    • Added Job.find_done_in_folders() to detect finished jobs in attached folders without triggering an actual copy.    
• experimaestro.core.objects.config:
    • Updated Task.submit() dry-run output to print [done](will copy from WS_NAME) in green when a job is available in an
    auxiliary folder.
• experimaestro.tests.test_folders:
    • Added unit test class TestDryRunFolderLookup verifying folder lookup logic and DRY_RUN stderr output.              
  