### PR TITLE
fix(experimaestro): restore submit() return value for tasks

### DIFF
--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -988,6 +988,26 @@ class ConfigInformation:
         else:
             self._simulate_submit(run_mode, launcher)
 
+        # Mark this configuration also
+        self.task = self.pyobject
+
+        from experimaestro.scheduler.experiment import experiment as _experiment
+
+        # Look up __submit__ or task_outputs on the value type (original class),
+        # not on the C proxy, to avoid MRO issues where ConfigMixin comes first
+        value_type = type(self.pyobject).__xpmtype__.value_type
+        if hasattr(value_type, "__submit__"):
+            add_action = _experiment.CURRENT.add_action if _experiment.CURRENT else None
+            self._taskoutput = value_type.__submit__(
+                self.pyobject, self.mark_output, add_action
+            )
+        elif hasattr(value_type, "task_outputs"):
+            self._taskoutput = value_type.task_outputs(self.pyobject, self.mark_output)
+        else:
+            self._taskoutput = self.task = self.pyobject
+
+        return self._taskoutput
+
     def _simulate_submit(self, run_mode, launcher):
         from experimaestro.scheduler import experiment
         from experimaestro.scheduler.workspace import RunMode
@@ -1032,27 +1052,7 @@ class ConfigInformation:
             for dep in self.job.dependencies:
                 cprint(f"   [Dependency] {dep}", color, file=sys.stderr)
 
-                print(file=sys.stderr)  # noqa: T201
-
-        # Mark this configuration also
-        self.task = self.pyobject
-
-        from experimaestro.scheduler.experiment import experiment as _experiment
-
-        # Look up __submit__ or task_outputs on the value type (original class),
-        # not on the C proxy, to avoid MRO issues where ConfigMixin comes first
-        value_type = type(self.pyobject).__xpmtype__.value_type
-        if hasattr(value_type, "__submit__"):
-            add_action = _experiment.CURRENT.add_action if _experiment.CURRENT else None
-            self._taskoutput = value_type.__submit__(
-                self.pyobject, self.mark_output, add_action
-            )
-        elif hasattr(value_type, "task_outputs"):
-            self._taskoutput = value_type.task_outputs(self.pyobject, self.mark_output)
-        else:
-            self._taskoutput = self.task = self.pyobject
-
-        return self._taskoutput
+            print(file=sys.stderr)  # noqa: T201
 
     def _prepare_configs(self, run_mode) -> List["Prepare"]:
         """The ``Prepare`` configs this task must depend on."""

--- a/src/experimaestro/core/objects/config.py
+++ b/src/experimaestro/core/objects/config.py
@@ -446,7 +446,7 @@ class ConfigInformation:
                         v.__xpm__.fuse_concrete_typevars(self.concrete_typevars)
                         self.fuse_concrete_typevars(v.__xpm__.concrete_typevars)
                 elif argument.required:
-                    raise AttributeError("Cannot set required attribute to None")
+                    raise AttributeError(f"Cannot set required attribute '{k}' to None")
                 else:
                     self.values[k] = None
 


### PR DESCRIPTION
In commit [cb7e5f7801f896a7dd995e0667456e312924f0c9](https://github.com/VictorMorand/experimaestro-python/commit/cb7e5f7801f896a7dd995e0667456e312924f0c9), submit() in experimaestro/core/objects/config.py was refactored to reduce McCabe complexity (C901). During that refactoring, the task output     
calculation and return self._taskoutput block was accidentally placed inside the _simulate_submit() helper method.

#### Impact

When running in NORMAL execution mode, submit() ran the normal branch, skipped _simulate_submit(), and reached the end of the method without a return statement, returning None. Consequently, calls like index = index_cfg.submit(...) returned None, triggering AttributeError: Cannot set required attribute 'index' to None.

#### Fix

Moved the self._taskoutput calculation and return self._taskoutput statement back to the top-level end of submit() so task outputs are returned across all execution modes