### PR TITLE
feat: support coupled parameters via config_dicts in grid_search

### DIFF
--- a/docs/source/experiments/grid_search.md
+++ b/docs/source/experiments/grid_search.md
@@ -76,6 +76,51 @@ grid_search:
 
 The keys in the `grid_search` block are dot-separated paths to the fields in your configuration.
 
+### Coupled Parameters (`config_dicts`)
+
+When you want to evaluate specific combinations of parameters together rather than computing their full Cartesian product, you can use `config_dicts` inside the `grid_search` block:
+
+```yaml
+id: my-experiment
+
+grid_search:
+  config_dicts:
+    - model: "bert-base-uncased"
+      batch_size: 32
+      lr: 2e-5
+    - model: "bert-large-uncased"
+      batch_size: 16
+      lr: 1e-5
+```
+
+or equivalently in one line:
+```yaml
+id: my-experiment
+
+grid_search:
+  config_dicts:
+    - {model: "bert-base-uncased", batch_size: 32,  lr: 2e-5 }
+    - {model: "bert-large-uncased",  batch_size: 16, lr: 1e-5 }
+```
+
+> [!IMPORTANT]
+> All dictionaries in `config_dicts` must define the exact same set of keys. If any dictionary has missing or extra keys, an error will be raised.
+
+You can also combine `config_dicts` with independent grid search parameters (defined inline or in `grid_search`). Experimaestro will compute the Cartesian product of the coupled parameter sets and the independent grid parameters:
+
+```yaml
+id: my-experiment
+
+grid_search:
+  seed: [42, 43, 44]
+  config_dicts:
+    - model: "bert-base-uncased"
+      batch_size: 32
+    - model: "bert-large-uncased"
+      batch_size: 16
+```
+This generates 3 x 2 = 6 configurations.
+
 ## Generating Permutations
 
 The grid search is managed manually in your `run` function. This gives you full control over how to manage experiment IDs, logging, and task submission.

--- a/src/experimaestro/experiments/configuration.py
+++ b/src/experimaestro/experiments/configuration.py
@@ -102,4 +102,6 @@ class ConfigurationBase:
 
     A dictionary where keys are dot-separated paths to configuration fields,
     and values are either a list of values or a dictionary with 'values_list' or 'values_range'.
+    Alternatively, can contain a 'config_dicts' key with a list of dictionaries defining
+    coupled parameter combinations (all dictionaries must have identical keys).
     """

--- a/src/experimaestro/experiments/grid.py
+++ b/src/experimaestro/experiments/grid.py
@@ -240,6 +240,108 @@ def finalize_config(obj: Any):
                     finalize_config(val)
 
 
+def _get_type_converter(target_type: Any):
+    """Returns a callable that attempts to convert a value to target_type."""
+    if target_type is Any:
+        return lambda value: value
+
+    if get_origin(target_type) is Annotated:
+        target_type = get_args(target_type)[0]
+
+    types_to_try = [
+        t
+        for t in (
+            get_args(target_type)
+            if get_origin(target_type) is Union
+            else [target_type]
+        )
+        if t is not type(None) and t is not GenericParams
+    ]
+
+    def converter(value: Any) -> Any:
+        if value is None:
+            return None
+        for t in types_to_try:
+            try:
+                return t(value)
+            except (ValueError, TypeError):
+                continue
+        return value
+
+    return converter
+
+
+def _validate_and_convert_config_dicts(
+    cfg: Any,
+    config_dicts: Any,
+    grid_params: Dict[str, GenericParams],
+    explicit_keys: set[str],
+) -> List[Dict[str, Any]]:
+    """
+    Validates config_dicts structure, checks for key consistency across all dictionaries,
+    prevents key collisions with independent grid parameters, and converts values to target types.
+    """
+    if isinstance(config_dicts, GenericParams):
+        config_dicts = config_dicts.values_list
+
+    if not isinstance(config_dicts, list):
+        raise ValueError(
+            f"'config_dicts' in grid_search must be a list of dictionaries, got {type(config_dicts).__name__}"
+        )
+
+    if len(config_dicts) == 0:
+        raise ValueError(
+            "'config_dicts' in grid_search must contain at least one dictionary"
+        )
+
+    for idx, item in enumerate(config_dicts):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"All elements in 'config_dicts' must be dictionaries, but item at index {idx} is of type {type(item).__name__}"
+            )
+        if len(item) == 0:
+            raise ValueError(
+                f"Dictionary at index {idx} in 'config_dicts' is empty. Dictionaries must contain parameter mappings."
+            )
+
+    expected_keys = set(config_dicts[0].keys())
+    for idx, item in enumerate(config_dicts[1:], start=1):
+        item_keys = set(item.keys())
+        if item_keys != expected_keys:
+            missing = expected_keys - item_keys
+            extra = item_keys - expected_keys
+            err_parts = []
+            if missing:
+                err_parts.append(f"missing keys: {sorted(missing)}")
+            if extra:
+                err_parts.append(f"extra keys: {sorted(extra)}")
+            raise ValueError(
+                f"All dictionaries in 'config_dicts' must have identical keys. "
+                f"Dict at index {idx} has keys {sorted(item_keys)}, expected {sorted(expected_keys)} "
+                f"({', '.join(err_parts)})"
+            )
+
+    active_grid_keys = {k for k, gp in grid_params.items() if gp.is_grid}
+    collisions = expected_keys.intersection(active_grid_keys | explicit_keys)
+    if collisions:
+        raise ValueError(
+            f"Conflicting grid search definition: parameters {sorted(collisions)} "
+            f"are defined both in 'config_dicts' and as independent grid search parameters"
+        )
+
+    converters = {}
+    for key in expected_keys:
+        target_type = get_nested_attr_type(cfg, key)
+        converters[key] = _get_type_converter(target_type)
+
+    converted_config_dicts = []
+    for item in config_dicts:
+        converted_item = {key: converters[key](val) for key, val in item.items()}
+        converted_config_dicts.append(converted_item)
+
+    return converted_config_dicts
+
+
 def generate_grid(cfg: Any) -> Tuple[List[Any], List[dict]]:
     """
     Generates a list of configuration permutations for a grid search, based
@@ -253,46 +355,40 @@ def generate_grid(cfg: Any) -> Tuple[List[Any], List[dict]]:
     # 1. Discover inline grid parameters
     grid_params = discover_grid_params(cfg)
 
-    # 2. Merge with explicit grid_search block
+    # 2. Extract config_dicts and merge remaining explicit grid_search block
+    raw_config_dicts = None
+    explicit_keys: set[str] = set()
     if hasattr(cfg, "grid_search") and cfg.grid_search:
-        for path, gp in cfg.grid_search.items():
+        explicit_grid = dict(cfg.grid_search)
+        raw_config_dicts = explicit_grid.pop("config_dicts", None)
+        explicit_keys = set(explicit_grid.keys())
+        for path, gp in explicit_grid.items():
             if isinstance(gp, GenericParams):
                 grid_params[path] = gp
             else:
                 grid_params[path] = GenericParams.from_any(gp)
 
-    # If no grid parameters found, just return the original config.
-    if not grid_params:
+    converted_config_dicts = None
+    if raw_config_dicts is not None:
+        converted_config_dicts = _validate_and_convert_config_dicts(
+            cfg, raw_config_dicts, grid_params, explicit_keys
+        )
+        # Remove config_dicts keys from grid_params since their values are provided by config_dicts
+        for key in converted_config_dicts[0].keys():
+            grid_params.pop(key, None)
+
+    # If no grid parameters and no config_dicts found, just return the original config.
+    if not grid_params and not converted_config_dicts:
         logger.info("no params to grid search, returning raw config")
         new_cfg = copy.deepcopy(cfg)
         finalize_config(new_cfg)
         return [new_cfg], [{}]
 
     param_paths = list(grid_params.keys())
-
     value_options = []
     for path in param_paths:
-        # get target type for this parameter from the config class using the path
         target_type = get_nested_attr_type(cfg, path)
-
-        def converter(value: Any) -> Any:
-            if target_type is Any:
-                return value
-            types_to_try = [
-                t
-                for t in (
-                    get_args(target_type)
-                    if get_origin(target_type) is Union
-                    else [target_type]
-                )
-                if t is not type(None)
-            ]
-            for t in types_to_try:
-                try:
-                    return t(value)
-                except (ValueError, TypeError):
-                    continue
-            return value
+        converter = _get_type_converter(target_type)
 
         gp_from_framework = (
             grid_params[path]
@@ -303,8 +399,17 @@ def generate_grid(cfg: Any) -> Tuple[List[Any], List[dict]]:
         converted_values = [converter(v) for v in raw_values]
         value_options.append(converted_values)
 
-    # Generate Cartesian product of all parameter values
-    grid_combinations = product(*value_options)
+    # Generate combinations
+    grid_combinations = list(product(*value_options)) if value_options else [()]
+    dict_combinations = converted_config_dicts if converted_config_dicts else [{}]
+
+    # Determine which config_dicts keys vary across items (only tag varying keys)
+    varying_dict_keys = set()
+    if converted_config_dicts and len(converted_config_dicts) > 1:
+        first_dict = converted_config_dicts[0]
+        for key in first_dict.keys():
+            if any(d[key] != first_dict[key] for d in converted_config_dicts[1:]):
+                varying_dict_keys.add(key)
 
     output_configs = []
     tags = []
@@ -314,11 +419,17 @@ def generate_grid(cfg: Any) -> Tuple[List[Any], List[dict]]:
         base_cfg.grid_search = {}
 
     logger.info("Building grid search configs")
-    for combination in grid_combinations:
+    for param_combo, cfg_dict in product(grid_combinations, dict_combinations):
         cfg_tags = {}
         new_cfg = copy.deepcopy(base_cfg)
-        for i, (path, value) in enumerate(zip(param_paths, combination)):
+
+        for i, (path, value) in enumerate(zip(param_paths, param_combo)):
             if len(value_options[i]) > 1:
+                cfg_tags[path] = value
+            set_nested_attr(new_cfg, path, value)
+
+        for path, value in cfg_dict.items():
+            if path in varying_dict_keys:
                 cfg_tags[path] = value
             set_nested_attr(new_cfg, path, value)
 

--- a/src/experimaestro/tests/test_grid.py
+++ b/src/experimaestro/tests/test_grid.py
@@ -134,3 +134,203 @@ def test_unique_value_in_tags():
     assert len(configs_multi) == 2
     assert tags_multi[0] == {"lr": 0.1}
     assert tags_multi[1] == {"lr": 0.01}
+
+
+def test_config_dicts_basic():
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+    cfg.grid_search = {
+        "config_dicts": [
+            {"lr": 0.01, "batch_size": 16},
+            {"lr": 0.001, "batch_size": 64},
+        ]
+    }
+    configs, tags = generate_grid(cfg)
+    assert len(configs) == 2
+    assert configs[0].lr == 0.01
+    assert configs[0].batch_size == 16
+    assert configs[1].lr == 0.001
+    assert configs[1].batch_size == 64
+    assert tags[0] == {"lr": 0.01, "batch_size": 16}
+    assert tags[1] == {"lr": 0.001, "batch_size": 64}
+
+
+def test_config_dicts_key_mismatch_error():
+    import pytest
+
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+
+    # Missing key
+    cfg.grid_search = {
+        "config_dicts": [
+            {"lr": 0.01, "batch_size": 16},
+            {"lr": 0.001},
+        ]
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"All dictionaries in 'config_dicts' must have identical keys.*missing keys: \['batch_size'\]",
+    ):
+        generate_grid(cfg)
+
+    # Extra key
+    cfg.grid_search = {
+        "config_dicts": [
+            {"lr": 0.01},
+            {"lr": 0.001, "batch_size": 16},
+        ]
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"All dictionaries in 'config_dicts' must have identical keys.*extra keys: \['batch_size'\]",
+    ):
+        generate_grid(cfg)
+
+
+def test_config_dicts_invalid_structure_error():
+    import pytest
+
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+
+    # Non-list
+    cfg.grid_search = {"config_dicts": "invalid"}
+    with pytest.raises(
+        ValueError, match=r"'config_dicts' in grid_search must be a list of dictionaries"
+    ):
+        generate_grid(cfg)
+
+    # Empty list
+    cfg.grid_search = {"config_dicts": []}
+    with pytest.raises(
+        ValueError, match=r"'config_dicts' in grid_search must contain at least one dictionary"
+    ):
+        generate_grid(cfg)
+
+    # Non-dict element
+    cfg.grid_search = {"config_dicts": [123]}
+    with pytest.raises(
+        ValueError, match=r"All elements in 'config_dicts' must be dictionaries"
+    ):
+        generate_grid(cfg)
+
+    # Empty dict
+    cfg.grid_search = {"config_dicts": [{}]}
+    with pytest.raises(
+        ValueError, match=r"Dictionary at index 0 in 'config_dicts' is empty"
+    ):
+        generate_grid(cfg)
+
+
+def test_config_dicts_collision_error():
+    import pytest
+
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+    cfg.grid_search = {
+        "lr": [0.1, 0.01],
+        "config_dicts": [{"lr": 0.05, "batch_size": 16}],
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"Conflicting grid search definition: parameters \['lr'\] are defined both in 'config_dicts' and as independent grid search parameters",
+    ):
+        generate_grid(cfg)
+
+
+def test_config_dicts_with_independent_grid():
+    cfg = MyConfig(id="test", lr=[0.1, 0.01], batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+    cfg.grid_search = {
+        "config_dicts": [
+            {"batch_size": 16},
+            {"batch_size": 64},
+        ]
+    }
+    configs, tags = generate_grid(cfg)
+    assert len(configs) == 4
+    assert configs[0].lr == 0.1 and configs[0].batch_size == 16
+    assert configs[1].lr == 0.1 and configs[1].batch_size == 64
+    assert configs[2].lr == 0.01 and configs[2].batch_size == 16
+    assert configs[3].lr == 0.01 and configs[3].batch_size == 64
+
+    assert tags[0] == {"lr": 0.1, "batch_size": 16}
+    assert tags[1] == {"lr": 0.1, "batch_size": 64}
+    assert tags[2] == {"lr": 0.01, "batch_size": 16}
+    assert tags[3] == {"lr": 0.01, "batch_size": 64}
+
+
+def test_config_dicts_tags_unique_filter():
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+
+    # batch_size is identical in both dicts, lr varies -> only lr in tags
+    cfg.grid_search = {
+        "config_dicts": [
+            {"lr": 0.01, "batch_size": 32},
+            {"lr": 0.001, "batch_size": 32},
+        ]
+    }
+    configs, tags = generate_grid(cfg)
+    assert len(configs) == 2
+    assert tags[0] == {"lr": 0.01}
+    assert tags[1] == {"lr": 0.001}
+
+    # Single dict in config_dicts -> tags should be empty
+    cfg_single = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg_single.lr = GenericParams.from_any(cfg_single.lr)
+    cfg_single.batch_size = GenericParams.from_any(cfg_single.batch_size)
+    cfg_single.grid_search = {
+        "config_dicts": [{"lr": 0.01, "batch_size": 16}]
+    }
+    configs_single, tags_single = generate_grid(cfg_single)
+    assert len(configs_single) == 1
+    assert tags_single[0] == {}
+
+
+def test_config_dicts_nested_paths():
+    cfg = MyConfig(id="test", lr=0.1, sub=MySubConfig(param=1))
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.sub.param = GenericParams.from_any(cfg.sub.param)
+    cfg.grid_search = {
+        "config_dicts": [
+            {"sub.param": 10},
+            {"sub.param": 20},
+        ]
+    }
+    configs, tags = generate_grid(cfg)
+    assert len(configs) == 2
+    assert configs[0].sub.param == 10
+    assert configs[1].sub.param == 20
+    assert tags[0] == {"sub.param": 10}
+    assert tags[1] == {"sub.param": 20}
+
+
+def test_config_dicts_generic_params_wrapper():
+    cfg = MyConfig(id="test", lr=0.1, batch_size=32)
+    cfg.lr = GenericParams.from_any(cfg.lr)
+    cfg.batch_size = GenericParams.from_any(cfg.batch_size)
+    # config_dicts wrapped in GenericParams (e.g. from Dict[str, GridSearch[Any]])
+    cfg.grid_search = {
+        "config_dicts": GenericParams.from_any([
+            {"lr": 0.01, "batch_size": 16},
+            {"lr": None, "batch_size": 32},
+        ])
+    }
+    configs, tags = generate_grid(cfg)
+    assert len(configs) == 2
+    assert configs[0].lr == 0.01
+    assert configs[0].batch_size == 16
+    assert configs[1].lr is None
+    assert configs[1].batch_size == 32
+    assert tags[0] == {"lr": 0.01, "batch_size": 16}
+    assert tags[1] == {"lr": None, "batch_size": 32}
+
+

--- a/src/experimaestro/tests/test_grid_validation.py
+++ b/src/experimaestro/tests/test_grid_validation.py
@@ -104,3 +104,67 @@ def test_unrecognized_key_in_validation():
         "Possible options are: range, range_mult, value, values_list, values_mult, values_range"
         in err_msg
     )
+
+
+def test_validate_attrs_with_config_dicts():
+    from experimaestro.experiments.grid import generate_grid
+
+    data = {
+        "id": "test",
+        "lr": 0.01,
+        "grid_search": {
+            "config_dicts": [
+                {"lr": 0.05, "sub.value": 10},
+                {"lr": 0.005, "sub.value": 20},
+            ]
+        },
+        "sub": {"value": 0},
+    }
+
+    cfg = validate_attrs(MainConfig, data)
+    configs, tags = generate_grid(cfg)
+
+    assert len(configs) == 2
+    assert configs[0].lr == 0.05
+    assert configs[0].sub.value == 10
+    assert configs[1].lr == 0.005
+    assert configs[1].sub.value == 20
+
+    assert tags[0] == {"lr": 0.05, "sub.value": 10}
+    assert tags[1] == {"lr": 0.005, "sub.value": 20}
+
+
+def test_validate_attrs_with_grid_search_annotation():
+    import attr
+    from typing import Dict, Any
+    from experimaestro.experiments.grid import generate_grid
+
+    @configuration()
+    class CustomConfig(ConfigurationBase):
+        grid_search: Dict[str, GridSearch[Any]] = attr.field(factory=dict)
+        lr: Optional[float] = 0.01
+        batch_size: Optional[int] = 32
+
+    data = {
+        "id": "test",
+        "grid_search": {
+            "config_dicts": [
+                {"lr": 0.05, "batch_size": 16},
+                {"lr": 0.005, "batch_size": 64},
+            ]
+        },
+    }
+
+    cfg = validate_attrs(CustomConfig, data)
+    configs, tags = generate_grid(cfg)
+
+    assert len(configs) == 2
+    assert configs[0].lr == 0.05
+    assert configs[0].batch_size == 16
+    assert configs[1].lr == 0.005
+    assert configs[1].batch_size == 64
+
+    assert tags[0] == {"lr": 0.05, "batch_size": 16}
+    assert tags[1] == {"lr": 0.005, "batch_size": 64}
+
+


### PR DESCRIPTION
Adds a proposition for supportting coupled parameter combinations under grid_search using config_dicts, avoiding full Cartesian products when parameters  should only be explored in specific pairs or sets.

#### Key Features & Changes:

• Coupled Parameters: Added `config_dicts: list[dict]` under grid_search in YAML/configs.
• Strict Key Consistency: Enforces identical keys across all dictionaries in config_dicts, raising a descriptive ValueError with missing/extra  
key diffs if mismatched.
• Collision Guard: Prevents defining the same parameter in config_dicts and as an independent grid search parameter.
• Cartesian Composition: Automatically computes the Cartesian product between independent grid parameters (inline or explicit) and config_dicts.
• Tag Filtering: Invariant parameters across config_dicts are omitted from permutation tags (consistent with single-value grid parameters).     
• Documentation & Tests: Added documentation in grid_search.md and 10 new unit/validation tests in test_grid.py and test_grid_validation.py.    

#### YAML Example:
```yaml
grid_search:
    seed: [42, 43]
    config_dicts:
    - reg_budget: null
        l2_reg: false
    - reg_budget: 0.2
        l2_reg: true
```
(Generates 2 × 2 = 4 configurations)
